### PR TITLE
Update CI to iOS 18.5 and Xcode 16.4 (Swift 6.1.2)

### DIFF
--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        xcode-version: ["16.0"]
+        xcode-version: ["16.4"]   # Swift 6.1.2
     runs-on: ${{ matrix.os }}
     env:
       UNSAFEHETEROGENEOUSBUFFER_SWIFTUI_COMPATIBILITY_TEST: 1
     steps:
       - uses: actions/checkout@v4
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: OpenSwiftUIProject/OpenSwiftUI/.github/actions/setup-xcode@main
         with:
           xcode-version: ${{ matrix.xcode-version }}
       - name: Run compatibility tests
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15]
-        xcode-version: ["16.0"]
-        ios-version: ["18.0"]
+        xcode-version: ["16.4"]   # Swift 6.1.2
+        ios-version: ["18.5"]
         ios-simulator-name: ["iPhone 16 Pro"]
     runs-on: ${{ matrix.os }}
     env:
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: OpenSwiftUIProject/OpenSwiftUI/.github/actions/setup-xcode@main
         with:
           xcode-version: ${{ matrix.xcode-version }}
       - name: Run compatibility tests

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        xcode-version: [16.0]
-        ios-version: ["18.0"]
+        xcode-version: ["16.4"]   # Swift 6.1.2
+        ios-version: ["18.5"]
         ios-simulator-name: ["iPhone 16 Pro"]
     runs-on: ${{ matrix.os }}
     env:
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: OpenSwiftUIProject/OpenSwiftUI/.github/actions/setup-xcode@main
         with:
           xcode-version: ${{ matrix.xcode-version }}
       - name: Swift version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: OpenSwiftUIProject/OpenSwiftUI/.github/actions/setup-xcode@main
         with:
-          xcode-version: 16.0
+          xcode-version: "16.4"
       - name: Build XCFramework
         run: ./Scripts/build_xcframework.sh
   macos_test:
@@ -25,14 +25,14 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        xcode-version: [16.0]
+        xcode-version: ["16.4"]   # Swift 6.1.2
     runs-on: ${{ matrix.os }}
     env:
       UNSAFEHETEROGENEOUSBUFFER_SWIFTUI_COMPATIBILITY_TEST: 0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: OpenSwiftUIProject/OpenSwiftUI/.github/actions/setup-xcode@main
         with:
           xcode-version: ${{ matrix.xcode-version }}
       - name: Build and run tests in debug mode with coverage

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,8 +10,9 @@ jobs:
   ubuntu_test:
     name: Execute tests on Ubuntu
     strategy:
+      fail-fast: false
       matrix:
-        swift_version: ["6.0.1"]
+        swift_version: ["6.1.2"]
     runs-on: ubuntu-22.04
     env:
       UNSAFEHETEROGENEOUSBUFFER_SWIFTUI_COMPATIBILITY_TEST: 0

--- a/Scripts/update.sh
+++ b/Scripts/update.sh
@@ -67,7 +67,7 @@ git add Sources/UnsafeHeterogeneousBuffer/UnsafeHeterogeneousBuffer.swift \
 git commit -m "$(cat <<EOF
 Update from OpenSwiftUI upstream
 
-Upstream commit: $UPSTREAM_COMMIT_HASH
+Upstream: https://github.com/OpenSwiftUIProject/OpenSwiftUI/blob/$UPSTREAM_COMMIT_HASH/Sources/OpenSwiftUICore/Data/DynamicProperty/UnsafeHeterogeneousBuffer.swift
 
 Transformations applied:
 - Changed package → public access control
@@ -76,7 +76,6 @@ Transformations applied:
 - Added compatibility test conditionals
 - Replaced OpenSwiftUI helpers with standard Swift
 
-OpenSwiftUI: https://github.com/OpenSwiftUIProject/OpenSwiftUI
 EOF
 )"
 


### PR DESCRIPTION
## Summary
- Update Xcode version from 16.0 to 16.4 (Swift 6.1.2)
- Update iOS simulator version from 18.0 to 18.5
- Update Swift version from 6.0.1 to 6.1.2 for Ubuntu tests
- Switch to OpenSwiftUI setup-xcode action for consistency with OpenAttributeGraph
- Add fail-fast: false to Ubuntu workflow for better CI resilience

## Motivation
Fixes CI failures related to missing iOS 18.0 simulator by upgrading to iOS 18.5 and aligning with OpenAttributeGraph's configuration.

## Test plan
- [ ] Verify macOS workflow runs successfully
- [ ] Verify Ubuntu workflow runs successfully
- [ ] Verify iOS workflow runs successfully with iOS 18.5 simulator
- [ ] Verify compatibility tests pass on both macOS and iOS